### PR TITLE
Minor fix: contributors link

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ Ainda, você deve definir as seguintes variáveis de ambiente:
 
 * **Leandro Luque** - *Initial work*
 
-See also the list of [contributors](https://github.com/your/project/contributors) who participated in this project.
+See also the list of [contributors](https://github.com/leluque/university-site-cms/graphs/contributors) who participated in this project.
 
 ## License
 


### PR DESCRIPTION
In the repository's README, the link to the project's contributors links to "your/project/contributors" instead of "graphs/contributors".

This pull request simply fixes the broken link. See [Files changed](https://github.com/leluque/university-site-cms/pull/9/files).